### PR TITLE
chore: modernize CI, harden Dockerfile, fix README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,14 @@
 name: ci
 on:
   push:
-    branches: [ master ]
-    tags: [ v* ]
+    branches: [ main ]
+    tags: [ "v*" ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
 
@@ -13,15 +17,15 @@ jobs:
     name: docker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/login-action@v1
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v3
+      - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
@@ -30,12 +34,15 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v6
         with:
           file: "Dockerfile"
           context: .
           platforms: linux/amd64
-          push: true
+          # Build (and validate) on every event, but only publish on
+          # pushes/tags — never publish images built from pull requests.
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 ARG ARGOCD_VERSION="v3.0.5"
 FROM quay.io/argoproj/argocd:$ARGOCD_VERSION
+
+LABEL org.opencontainers.image.source="https://github.com/snapp-incubator/docker-argocd" \
+      org.opencontainers.image.description="Argo CD with helm-secrets (SOPS/vals) baked in"
+
 ARG SOPS_VERSION=3.9.0
 ARG KUBECTL_VERSION=1.30.2
 ARG VALS_VERSION=0.37.3
 ARG HELM_SECRETS_VERSION=4.6.5
+# Pin curl instead of pulling "latest" so builds are reproducible.
+ARG CURL_VERSION=8.17.0
 
 # vals or sops
 ENV HELM_SECRETS_BACKEND=sops \
@@ -29,9 +35,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /gitops-tools/helm-plugins
 
-RUN \ 
+RUN \
     GO_ARCH=$(uname -m | sed -e 's/x86_64/amd64/') && \
-    wget -qO "/gitops-tools/curl" "https://github.com/moparisthebest/static-curl/releases/latest/download/curl-${GO_ARCH}" && \
+    wget -qO "/gitops-tools/curl" "https://github.com/moparisthebest/static-curl/releases/download/v${CURL_VERSION}/curl-${GO_ARCH}" && \
     true
 
 RUN \

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Only the `argocd-repo-server` component requires the custom image. Other Argo CD
 ```yaml
 repoServer:
   image:
-    repository: camptocamp/argocd
-    tag: v3.0.5_c2c.1
+    repository: ghcr.io/snapp-incubator/docker-argocd
+    tag: v3.0.5-c1
     imagePullPolicy: ""
 ```
 
@@ -33,7 +33,7 @@ Before creating the Kubernetes secret, export your GPG private key in ASCII-armo
 gpg --armor --export-secret-keys <key-id> > gpg.privkey.asc
 ```
 
-Replace `<key-id>` with your actual GPG key ID. This file (`key.asc`) will be used in the next step.
+Replace `<key-id>` with your actual GPG key ID. This file (`gpg.privkey.asc`) will be used in the next step.
 
 ---
 


### PR DESCRIPTION
## CI (`.github/workflows/ci.yml`)
- **Fix the trigger branch `master` → `main`.** The repo's default branch is `main`, so the existing `push`/`pull_request` triggers never fired — only tag builds ran. This restores branch + PR CI.
- Bump actions to current majors: `checkout@v4`, `setup-qemu@v3`, `setup-buildx@v3`, `login@v3`, `metadata@v5`, `build-push@v6` (old v1/v2 use deprecated runners).
- Add **GHA build cache** (`cache-from/to: type=gha`) for faster rebuilds.
- Add least-privilege `permissions:` and **don't publish images built from PRs** (`push: ${{ github.event_name != 'pull_request' }}`) — PRs still build to validate.

## Dockerfile
- **Pin curl** (`ARG CURL_VERSION=8.17.0`) instead of `releases/latest/...` so builds are reproducible (verified the pinned amd64 asset resolves).
- Drop a trailing-space `RUN \` line; add OCI `image.source`/`description` labels.

## README
- Fix the leftover **`camptocamp/argocd`** image reference → `ghcr.io/snapp-incubator/docker-argocd`.
- Fix `key.asc` → `gpg.privkey.asc` filename mismatch.

No base-version or tooling-version changes here (kept focused); the Argo CD bump is handled by the upstream-release watcher in #2.